### PR TITLE
1.3.0

### DIFF
--- a/src/main/java/dev/projectg/geyserhub/GeyserHubMain.java
+++ b/src/main/java/dev/projectg/geyserhub/GeyserHubMain.java
@@ -28,6 +28,7 @@ public class GeyserHubMain extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        long start = System.currentTimeMillis();
         plugin = this;
         new Metrics(this, 11427);
         // getting the logger forces the config to load before our loadConfiguration() is called...
@@ -86,6 +87,8 @@ public class GeyserHubMain extends JavaPlugin {
 
         // The random interval broadcast module
         Broadcast.startBroadcastTimer(getServer().getScheduler());
+
+        logger.info("Took " + (System.currentTimeMillis() - start) + "ms to boot GeyserHub.");
     }
 
     public void initializeScoreboard() {

--- a/src/main/java/dev/projectg/geyserhub/GeyserHubMain.java
+++ b/src/main/java/dev/projectg/geyserhub/GeyserHubMain.java
@@ -2,6 +2,7 @@ package dev.projectg.geyserhub;
 
 import dev.projectg.geyserhub.command.GeyserHubCommand;
 import dev.projectg.geyserhub.config.ConfigManager;
+import dev.projectg.geyserhub.module.menu.AccessItemRegistry;
 import dev.projectg.geyserhub.module.menu.CommonMenuListeners;
 import dev.projectg.geyserhub.module.menu.java.JavaMenuListeners;
 import dev.projectg.geyserhub.module.menu.bedrock.BedrockFormRegistry;
@@ -54,6 +55,7 @@ public class GeyserHubMain extends JavaPlugin {
         getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
 
         // Load forms
+        AccessItemRegistry accessItemRegistry = new AccessItemRegistry();
         BedrockFormRegistry bedrockFormRegistry = new BedrockFormRegistry();
         JavaMenuRegistry javaMenuRegistry = new JavaMenuRegistry();
 
@@ -63,7 +65,7 @@ public class GeyserHubMain extends JavaPlugin {
         // todo: sort all of this, and make checking for enable value in config consistent
 
         // Listeners for the Bedrock and Java menus
-        Bukkit.getServer().getPluginManager().registerEvents(new CommonMenuListeners(bedrockFormRegistry, javaMenuRegistry), this);
+        Bukkit.getServer().getPluginManager().registerEvents(new CommonMenuListeners(accessItemRegistry, bedrockFormRegistry, javaMenuRegistry), this);
         Bukkit.getServer().getPluginManager().registerEvents(new JavaMenuListeners(javaMenuRegistry), this);
 
         // Listener the Join Teleporter module

--- a/src/main/java/dev/projectg/geyserhub/command/GeyserHubCommand.java
+++ b/src/main/java/dev/projectg/geyserhub/command/GeyserHubCommand.java
@@ -1,8 +1,7 @@
 package dev.projectg.geyserhub.command;
 
 import dev.projectg.geyserhub.SelectorLogger;
-import dev.projectg.geyserhub.module.menu.bedrock.BedrockForm;
-import dev.projectg.geyserhub.module.menu.java.JavaMenu;
+import dev.projectg.geyserhub.module.menu.MenuUtils;
 import dev.projectg.geyserhub.module.menu.java.JavaMenuRegistry;
 import dev.projectg.geyserhub.reloadable.ReloadableRegistry;
 import dev.projectg.geyserhub.module.menu.bedrock.BedrockFormRegistry;
@@ -13,7 +12,6 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
-import org.geysermc.floodgate.api.FloodgateApi;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -32,11 +30,11 @@ public class GeyserHubCommand implements CommandExecutor {
     private static final String NO_PERMISSION = "Sorry, you don't have permission to run that command!";
     private static final String UNKNOWN = "Sorry, that's an unknown command!";
 
-    private final BedrockFormRegistry bedrockRegistry;
+    private final BedrockFormRegistry bedrockFormRegistry;
     private final JavaMenuRegistry javaMenuRegistry;
 
-    public GeyserHubCommand(BedrockFormRegistry bedrockRegistry, JavaMenuRegistry javaMenuRegistry) {
-        this.bedrockRegistry = bedrockRegistry;
+    public GeyserHubCommand(BedrockFormRegistry bedrockFormRegistry, JavaMenuRegistry javaMenuRegistry) {
+        this.bedrockFormRegistry = bedrockFormRegistry;
         this.javaMenuRegistry = javaMenuRegistry;
     }
 
@@ -111,38 +109,14 @@ public class GeyserHubCommand implements CommandExecutor {
      * @param formName the form name to send
      */
     private void sendForm(@Nonnull CommandSender commandSender, @Nonnull String formName) {
-        // todo: same code is in MenuUtils
         if (commandSender instanceof Player) {
-            Player player = (Player) commandSender;
-            if (FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId())) {
-                if (bedrockRegistry.isEnabled()) {
-                    if (bedrockRegistry.getFormNames().contains(formName)) {
-                        BedrockForm form = Objects.requireNonNull(bedrockRegistry.getMenu(formName));
-                        form.sendForm(FloodgateApi.getInstance().getPlayer(player.getUniqueId()));
-                    } else {
-                        sendMessage(player, SelectorLogger.Level.SEVERE, "Sorry, that form doesn't exist! Specify a form with \"/ghub form <form>\"");
-                    }
-                } else {
-                    sendMessage(player, SelectorLogger.Level.SEVERE, "Sorry, Bedrock forms are disabled!");
-                }
-            } else {
-                if (javaMenuRegistry.isEnabled()) {
-                    if (javaMenuRegistry.getMenuNames().contains(formName)) {
-                        JavaMenu menu = Objects.requireNonNull(javaMenuRegistry.getMenu(formName));
-                        menu.sendMenu(player);
-                    } else {
-                        sendMessage(player, SelectorLogger.Level.SEVERE, "Sorry, that form doesn't exist! Specify a form with \"/ghub form <form>\"");
-                    }
-                } else {
-                    sendMessage(player, SelectorLogger.Level.SEVERE, "Sorry, Java menus are disabled!");
-                }
-            }
+            MenuUtils.sendForm((Player) commandSender, bedrockFormRegistry, javaMenuRegistry, formName);
         } else if (commandSender instanceof ConsoleCommandSender) {
             sendHelp(commandSender);
         }
     }
 
-    private void sendMessage(@Nonnull CommandSender sender, @Nonnull SelectorLogger.Level level, @Nonnull String message) {
+    public static void sendMessage(@Nonnull CommandSender sender, @Nonnull SelectorLogger.Level level, @Nonnull String message) {
         Objects.requireNonNull(sender);
         Objects.requireNonNull(level);
         Objects.requireNonNull(message);

--- a/src/main/java/dev/projectg/geyserhub/command/GeyserHubCommand.java
+++ b/src/main/java/dev/projectg/geyserhub/command/GeyserHubCommand.java
@@ -54,9 +54,7 @@ public class GeyserHubCommand implements CommandExecutor {
         switch (args[0]) {
             case "reload":
                 if (commandSender.hasPermission("geyserhub.reload")) {
-                    if (ReloadableRegistry.reloadAll()) {
-                        sendMessage(commandSender, SelectorLogger.Level.INFO, "Successfully reloaded.");
-                    } else {
+                    if (!ReloadableRegistry.reloadAll()) {
                         sendMessage(commandSender, SelectorLogger.Level.SEVERE, "There was an error reloading something! Please check the server console for further information.");
                     }
                 } else {

--- a/src/main/java/dev/projectg/geyserhub/config/ConfigId.java
+++ b/src/main/java/dev/projectg/geyserhub/config/ConfigId.java
@@ -5,7 +5,7 @@ package dev.projectg.geyserhub.config;
  */
 public enum ConfigId {
     MAIN("config.yml", 4),
-    SELECTOR("selector.yml", 1);
+    SELECTOR("selector.yml", 2);
 
     public static final ConfigId[] VALUES = values();
 

--- a/src/main/java/dev/projectg/geyserhub/config/ConfigManager.java
+++ b/src/main/java/dev/projectg/geyserhub/config/ConfigManager.java
@@ -2,6 +2,8 @@ package dev.projectg.geyserhub.config;
 
 import dev.projectg.geyserhub.GeyserHubMain;
 import dev.projectg.geyserhub.SelectorLogger;
+import dev.projectg.geyserhub.config.updaters.SELECTOR_1;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -9,13 +11,18 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 
 public class ConfigManager {
 
     private static ConfigManager CONFIG_MANAGER;
+    private static final Map<ConfigId, Map<Integer, Class<? extends ConfigUpdater>>> updaters = new HashMap<>();
+
+    static {
+        // todo: this is awful but oh well
+        updaters.put(ConfigId.SELECTOR, Collections.singletonMap(1, SELECTOR_1.class));
+    }
 
     private final Map<ConfigId, FileConfiguration> configurations = new HashMap<>();
 
@@ -54,6 +61,7 @@ public class ConfigManager {
     public boolean loadConfig(@Nonnull ConfigId config) {
         GeyserHubMain plugin = GeyserHubMain.getInstance();
 
+        // Get the file
         File file = new File(plugin.getDataFolder(), config.fileName);
         if (!file.exists()) {
             if (!file.getParentFile().exists()) {
@@ -69,6 +77,8 @@ public class ConfigManager {
             }
             plugin.saveResource(config.fileName, false);
         }
+
+        // Load the file into a config
         FileConfiguration configuration = new YamlConfiguration();
         try {
             configuration.load(file);
@@ -76,21 +86,78 @@ public class ConfigManager {
             e.printStackTrace();
             return false;
         }
+
+        // Check if it is the right version, attempt to update
         if (!configuration.contains("Config-Version", true)) {
             logger.severe("Config-Version does not exist in" + config.fileName + " !");
             return false;
         } else if (!configuration.isInt("Config-Version")) {
             logger.severe("Config-Version is not an integer in" + config.fileName + " !");
             return false;
-        } else if (configuration.getInt("Config-Version") != config.version) {
-            logger.severe("Mismatched config version in " + config.fileName + " ! Generate a new config and migrate your settings!");
-            return false;
-        } else {
-            plugin.reloadConfig();
-            this.configurations.put(config, configuration);
-            logger.debug("Loaded configuration " + config.fileName + " successfully");
-            return true;
         }
+
+        int oldVersion = configuration.getInt("Config-Version");
+        if (oldVersion != config.version) {
+            logger.warn("Mismatched config version in " + config.fileName + ". Expected version " + config.version + ", file is " + oldVersion);
+
+            Map<Integer, Class<? extends ConfigUpdater>> relevantUpdaters = updaters.get(config);
+            if (relevantUpdaters != null && !relevantUpdaters.isEmpty()) {
+                logger.info("Attempting to automatically update " + config.fileName + ". Comments will be lost.");
+
+                try {
+                    String[] splitName = config.fileName.split("\\.");
+                    configuration.save(new File(plugin.getDataFolder(), splitName[0] + "-old." + splitName[1]));
+                } catch (IOException e) {
+                    logger.severe("Failed to make a copy of " + config.fileName + " before attempting to automatically update it");
+                    e.printStackTrace();
+                    return false;
+                }
+
+                for (int version = oldVersion; version < config.version; version++) {
+                    if (relevantUpdaters.containsKey(version)) {
+                        logger.info("Updating " + config.fileName + " from version " + version + " to " + (version + 1));
+                        try {
+                            ConfigUpdater updater = ((ConfigUpdater) relevantUpdaters.get(version).getConstructors()[0].newInstance());
+
+                            boolean fail;
+                            try {
+                                fail = !updater.update(configuration);
+                            } catch (IllegalArgumentException e) {
+                                fail = true;
+                                e.printStackTrace();
+                            }
+                            if (fail) {
+                                logger.severe("Failed to update " + config.fileName + " from version " + version + " to " + (version + 1));
+                                break;
+                            }
+                        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                            logger.severe("Failed to fetch a ConfigUpdater which should exist");
+                            e.printStackTrace();
+                            break;
+                        }
+                    }
+                }
+
+                try {
+                    configuration.save(file);
+                } catch (IOException e) {
+                    logger.severe("Failed to save the updated version of " + config.fileName);
+                    e.printStackTrace();
+                }
+            }
+
+            if (configuration.getInt("Config-Version") == config.version) {
+                logger.info(config.fileName + " was successfully updated to the latest version");
+            } else {
+                return false;
+            }
+        }
+
+
+        // plugin.reloadConfig(); //todo is this line even necessary?
+        this.configurations.put(config, configuration);
+        logger.debug("Loaded configuration " + config.fileName + " successfully");
+        return true;
     }
 
     /**
@@ -110,4 +177,27 @@ public class ConfigManager {
         return configurations;
     }
 
+    /**
+     * Converts a ConfigurationSection into a Map, whose keys and values are those of the ConfigurationSection.
+     * Child ConfigurationSections will also be converted into Maps.
+     */
+    public static Map<String, Object> getMap(@Nonnull ConfigurationSection config) {
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        for (String key : config.getKeys(false)) {
+            Object value;
+            if (config.isConfigurationSection(key)) {
+                ConfigurationSection subSection = config.getConfigurationSection(key);
+                Objects.requireNonNull(subSection);
+
+                value = getMap(subSection);
+            } else {
+                value = config.get(key);
+            }
+
+            map.put(key, value);
+        }
+
+        return map;
+    }
 }

--- a/src/main/java/dev/projectg/geyserhub/config/ConfigManager.java
+++ b/src/main/java/dev/projectg/geyserhub/config/ConfigManager.java
@@ -149,6 +149,7 @@ public class ConfigManager {
             if (configuration.getInt("Config-Version") == config.version) {
                 logger.info(config.fileName + " was successfully updated to the latest version");
             } else {
+                logger.warn("Failed to fully update " + config.fileName + " from version " + oldVersion + " to " + config.version);
                 return false;
             }
         }

--- a/src/main/java/dev/projectg/geyserhub/config/ConfigUpdater.java
+++ b/src/main/java/dev/projectg/geyserhub/config/ConfigUpdater.java
@@ -1,0 +1,14 @@
+package dev.projectg.geyserhub.config;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+public interface ConfigUpdater {
+
+    /**
+     * Updates a configuration from a version to the next higher version
+     * @param config The config to update
+     * @return True if it was a success, false if there was a failure
+     * @throws IllegalArgumentException If there was an unexpected difference in the given {@link ConfigurationSection}
+     */
+    boolean update(ConfigurationSection config) throws IllegalArgumentException;
+}

--- a/src/main/java/dev/projectg/geyserhub/config/updaters/SELECTOR_1.java
+++ b/src/main/java/dev/projectg/geyserhub/config/updaters/SELECTOR_1.java
@@ -1,0 +1,50 @@
+package dev.projectg.geyserhub.config.updaters;
+
+import dev.projectg.geyserhub.config.ConfigManager;
+import dev.projectg.geyserhub.config.ConfigUpdater;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class SELECTOR_1 implements ConfigUpdater {
+
+    @Override
+    public boolean update(ConfigurationSection config) throws IllegalArgumentException {
+        if (!config.contains("Config-Version", true) || config.getInt("Config-Version") != 1) {
+            throw new IllegalArgumentException("Config is not version 1");
+        }
+
+        if (!config.contains("Selector-Item", true) || !config.isConfigurationSection("Selector-Item")) {
+            throw new IllegalArgumentException("Config does not contain configuration section 'Selector-Item'");
+        }
+
+        // Get the mutable ConfigurationSection
+        ConfigurationSection items = config.getConfigurationSection("Selector-Item");
+        Objects.requireNonNull(items);
+        // Remove it from the parent afterwards, since it must be renamed
+        config.set("Selector-Item", null);
+
+        // A map containing the same information as the configuration section
+        Map<String, Object> defaultItem = ConfigManager.getMap(items);
+        defaultItem.put("Form", "default"); // new data
+
+        // Clear the section
+        for (String key : items.getKeys(false)) {
+            // Remove the old single access item data
+            items.set(key, null);
+        }
+
+        // Add the enable key and put the old single access item data in a subsection
+        items.set("Enable", true); // new data
+        items.createSection("Items.default", defaultItem); // re-insert the old data into the default access item
+
+        // Add the Selector-Item section back in, under the new name
+        config.createSection("Access-Items", ConfigManager.getMap(items));
+
+        // bump version
+        config.set("Config-Version", 2);
+
+        return true;
+    }
+}

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItem.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItem.java
@@ -27,7 +27,9 @@ public class AccessItem {
     public final String itemId;
 
     /**
-     * The inventory slot for the item to be in by default
+     * The hotbar slot for the item to be, by default.
+     * Should be placed elsewhere in the hotbar if not possible.
+     * Should not be given if the hotbar is full.
      */
     public final int slot;
 

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItem.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItem.java
@@ -1,11 +1,13 @@
 package dev.projectg.geyserhub.module.menu;
 
+import dev.projectg.geyserhub.GeyserHubMain;
 import dev.projectg.geyserhub.utils.PlaceholderUtils;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -13,17 +15,64 @@ import java.util.Objects;
 
 public class AccessItem {
 
+    /**
+     * A key that should be of type {@link #ACCESS_ITEM_KEY_TYPE}, with the value being the {@link #itemId}
+     */
+    public static final NamespacedKey ACCESS_ITEM_KEY = new NamespacedKey(GeyserHubMain.getInstance(), "geyserHubAccessItem");
+    public static final PersistentDataType<String, String> ACCESS_ITEM_KEY_TYPE = PersistentDataType.STRING;
+
+    /**
+     * The id of the access item.
+     */
     public final String itemId;
+
+    /**
+     * The inventory slot for the item to be in by default
+     */
     public final int slot;
+
     private final String displayName;
     private final Material material;
     private final List<String> lore;
 
+    /**
+     * True for players to receive it when they join
+     */
     public final boolean onJoin;
+
+    /**
+     * True for players to be able to drop the item
+     */
     public final boolean allowDrop;
+
+    /**
+     * True for the item to be destroyed when dropped
+     */
     public final boolean destroyDropped;
+
+    /**
+     * True for players to be able to move the item
+     */
     public final boolean allowMove;
 
+    /**
+     * The form/menu name to open.
+     */
+    public final String formName;
+
+    /**
+     * Immutable Access Item to open a form.
+     * @param itemId The ID of the form (the parent key in the config, generally)
+     * @param slot The slot of the inventory this should be put in by default
+     * @param displayName The Display Name of the ItemStack, supports placeholders.
+     * @param material The material for the ItemStack to be
+     * @param lore The lore for the ItemStack
+     * @param onJoin True for players to receive it when they join
+     * @param allowDrop True for players to be able to drop the item
+     * @param destroyDropped True for the item to be destroyed when dropped
+     * @param allowMove True for players to be able to move the item
+     * @param formName The form/menu name to open.
+     */
     public AccessItem(@Nonnull String itemId, int slot, @Nonnull String displayName, @Nonnull Material material, @Nonnull List<String> lore,
                       boolean onJoin, boolean allowDrop, boolean destroyDropped, boolean allowMove,
                       @Nonnull String formName) {
@@ -41,23 +90,31 @@ public class AccessItem {
         this.allowDrop = allowDrop;
         this.destroyDropped = destroyDropped;
         this.allowMove = allowMove;
-    }
 
+        this.formName = formName;
+    }
 
     private ItemStack createItemStack(@Nonnull String displayName, @Nonnull Material material, @Nonnull List<String> lore) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = Objects.requireNonNull(item.getItemMeta());
         meta.setDisplayName(displayName);
         meta.setLore(lore);
-        meta.getPersistentDataContainer().get(new NamespacedKey("geyserHubAccessItem", ))
+        meta.getPersistentDataContainer().set(ACCESS_ITEM_KEY, ACCESS_ITEM_KEY_TYPE, itemId);
         item.setItemMeta(meta);
         return item;
     }
 
+    /**
+     * @return The ItemStack of the access item, with no placeholders set.
+     */
     public ItemStack getItemStack() {
         return createItemStack(displayName, material, lore);
     }
 
+    /**
+     * @param player The player to apply to placeholders
+     * @return The ItemStack of the access item, with placeholders in the display name and lore set according to the given player
+     */
     public ItemStack getItemStack(@Nonnull Player player) {
         String displayName = PlaceholderUtils.setPlaceholders(player, this.displayName);
         List<String> lore = PlaceholderUtils.setPlaceholders(player, this.lore);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
@@ -1,0 +1,112 @@
+package dev.projectg.geyserhub.module.menu;
+
+
+import dev.projectg.geyserhub.GeyserHubMain;
+import dev.projectg.geyserhub.SelectorLogger;
+import dev.projectg.geyserhub.config.ConfigId;
+import dev.projectg.geyserhub.reloadable.Reloadable;
+import dev.projectg.geyserhub.reloadable.ReloadableRegistry;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.*;
+
+public class AccessItemRegistry implements Reloadable {
+
+    private final GeyserHubMain geyserHub;
+    private final Map<String, AccessItem> items = new HashMap<>();
+
+    public AccessItemRegistry(GeyserHubMain geyserHub) {
+        this.geyserHub = geyserHub;
+        ReloadableRegistry.registerReloadable(this);
+    }
+
+    private void fetchItems() {
+        SelectorLogger logger = SelectorLogger.getLogger();
+
+        ConfigurationSection configItems = geyserHub.getConfigManager().getFileConfiguration(ConfigId.SELECTOR);
+        for (String itemId : configItems.getKeys(false)) {
+            if (!configItems.isConfigurationSection(itemId)) {
+                continue;
+            }
+            ConfigurationSection itemSection = configItems.getConfigurationSection(itemId);
+            Objects.requireNonNull(itemSection);
+
+            // Get the material
+            Material material;
+            if (itemSection.contains("Selector-Item.Material", true)) {
+                String materialName = itemSection.getString("Selector-Item.Material");
+                Objects.requireNonNull(materialName);
+                material = Material.getMaterial(materialName);
+                if (material == null) {
+                    SelectorLogger.getLogger().warn("Failed to find a Material for '" + materialName + "' for access item: " + itemId + ". Defaulting to COMPASS for the access item.");
+                    material = Material.COMPASS;
+                }
+            } else {
+                SelectorLogger.getLogger().warn("Failed to find Selector-Item. " + itemId + ".Material in the config! Defaulting to COMPASS.");
+                material = Material.COMPASS;
+            }
+
+            // Create a new item with the material, get the meta
+            ItemStack item = new ItemStack(material);
+            ItemMeta meta = item.getItemMeta();
+            if (meta == null) {
+                logger.warn("Failed to create access item " + itemId + " with Material " + material + " because the ItemMeta returned null.");
+                continue;
+            }
+
+            // Set the display name in the meta
+            String name;
+            if (itemSection.contains("Selector-Item.Name", true)) {
+                name = itemSection.getString("Selector-Item.Name");
+                Objects.requireNonNull(name);
+            } else {
+                SelectorLogger.getLogger().warn("Failed to find Selector-Item. " + itemId + ".Name in the config! Defaulting to '§6Server Selector'.");
+                name = "§6Server Selector";
+            }
+            meta.setDisplayName(name);
+
+            // Set the lore in the meta
+            List<String> lore;
+            if (itemSection.contains("Selector-Item.Lore", true) && itemSection.isList("Selector-Item.Lore")) {
+                lore = itemSection.getStringList("Selector-Item.Lore");
+            } else {
+                lore = Collections.emptyList();
+            }
+            meta.setLore(lore);
+
+            // Set the meta and set the field
+            item.setItemMeta(meta);
+
+            if (itemSection.contains("Slot", true) && itemSection.isInt("Slot")) {
+                if ( !itemSection.contains("Join") || !itemSection.contains("Allow-Drop") || !itemSection.contains("Destroy-Dropped") || !itemSection.contains("Allow-Move")
+                || !itemSection.isBoolean("Join") || !itemSection.isBoolean("Allow-Drop") || !itemSection.isBoolean("Destroy-Dropped") || !itemSection.isBoolean("Allow-Move")) {
+                    logger.warn("Failed to create access item " + itemId + " because it is missing config values!");
+                    continue;
+                }
+                int slot = Math.abs(configItems.getInt("Slot"));
+                items.put(itemId, new AccessItem(itemId, slot, name, material, lore,
+                        itemSection.getBoolean("Join"),
+                        itemSection.getBoolean("Allow-Drop"),
+                        itemSection.getBoolean("Destroy-Dropped"),
+                        itemSection.getBoolean("Allow-Move")));
+            } else {
+                logger.warn("Failed to create access item " + itemId + " because a Slot Integer value wasn't given.");
+            }
+        }
+    }
+
+    @Override
+    public boolean reload() {
+        items.clear();
+        fetchItems();
+
+        return true;
+    }
+
+    public HashMap<String, AccessItem> getAccessItems() {
+        return new HashMap<>(items);
+    }
+}

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
@@ -159,7 +159,8 @@ public class AccessItemRegistry implements Reloadable {
     }
 
     /**
-     * Attempt to retrieve the Access Item ID that an ItemStack points to
+     * Attempt to retrieve the Access Item ID that an ItemStack points to. The Access Item ID may or may not refer
+     * to an actual AccessItem
      * @param itemStack The ItemStack to check
      * @return The AccessItem ID if the ItemStack contained the name, null if not.
      */

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
@@ -8,25 +8,44 @@ import dev.projectg.geyserhub.reloadable.Reloadable;
 import dev.projectg.geyserhub.reloadable.ReloadableRegistry;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 
 public class AccessItemRegistry implements Reloadable {
 
-    private final GeyserHubMain geyserHub;
+    private boolean isEnabled = false;
     private final Map<String, AccessItem> items = new HashMap<>();
 
-    public AccessItemRegistry(GeyserHubMain geyserHub) {
-        this.geyserHub = geyserHub;
+    public AccessItemRegistry() {
+        load();
         ReloadableRegistry.registerReloadable(this);
     }
 
-    private void fetchItems() {
+    private void load() {
         SelectorLogger logger = SelectorLogger.getLogger();
 
-        ConfigurationSection configItems = geyserHub.getConfigManager().getFileConfiguration(ConfigId.SELECTOR);
+        FileConfiguration selectorConfig = GeyserHubMain.getInstance().getConfigManager().getFileConfiguration(ConfigId.SELECTOR);
+        if (!selectorConfig.contains("Selector-Item") || !selectorConfig.isConfigurationSection("Selector-Item")) {
+            logger.warn("Not creating any access items because selector.yml does not contain the Selector-Item config!");
+            return;
+        }
+        ConfigurationSection accessSection = Objects.requireNonNull(selectorConfig.getConfigurationSection("Selector-Item"));
+        if (accessSection.contains("Enable") && accessSection.isBoolean("Enable")) {
+            if (!accessSection.getBoolean("Enable")) {
+                return;
+            }
+        }
+        if (!selectorConfig.contains("Items") || !selectorConfig.isConfigurationSection("Items")) {
+            logger.warn("Not creating any access items because Selector-Item in selector.yml does not list any items!");
+            return;
+        }
+        ConfigurationSection configItems = Objects.requireNonNull(selectorConfig.getConfigurationSection("Items"));
+
         for (String itemId : configItems.getKeys(false)) {
             if (!configItems.isConfigurationSection(itemId)) {
                 continue;
@@ -36,8 +55,8 @@ public class AccessItemRegistry implements Reloadable {
 
             // Get the material
             Material material;
-            if (itemSection.contains("Selector-Item.Material", true)) {
-                String materialName = itemSection.getString("Selector-Item.Material");
+            if (itemSection.contains("Material", true)) {
+                String materialName = itemSection.getString("Material");
                 Objects.requireNonNull(materialName);
                 material = Material.getMaterial(materialName);
                 if (material == null) {
@@ -59,7 +78,7 @@ public class AccessItemRegistry implements Reloadable {
 
             // Set the display name in the meta
             String name;
-            if (itemSection.contains("Selector-Item.Name", true)) {
+            if (itemSection.contains("Name", true)) {
                 name = itemSection.getString("Selector-Item.Name");
                 Objects.requireNonNull(name);
             } else {
@@ -70,7 +89,7 @@ public class AccessItemRegistry implements Reloadable {
 
             // Set the lore in the meta
             List<String> lore;
-            if (itemSection.contains("Selector-Item.Lore", true) && itemSection.isList("Selector-Item.Lore")) {
+            if (itemSection.contains("Lore", true) && itemSection.isList("Lore")) {
                 lore = itemSection.getStringList("Selector-Item.Lore");
             } else {
                 lore = Collections.emptyList();
@@ -80,6 +99,12 @@ public class AccessItemRegistry implements Reloadable {
             // Set the meta and set the field
             item.setItemMeta(meta);
 
+            if (!itemSection.contains("Form") || !itemSection.isString("Form")) {
+                logger.warn("Access item: " + itemId + " does not contain a form! Not registering the item.");
+                continue;
+            }
+            String formName = Objects.requireNonNull(itemSection.getString("Form"));
+
             if (itemSection.contains("Slot", true) && itemSection.isInt("Slot")) {
                 if ( !itemSection.contains("Join") || !itemSection.contains("Allow-Drop") || !itemSection.contains("Destroy-Dropped") || !itemSection.contains("Allow-Move")
                 || !itemSection.isBoolean("Join") || !itemSection.isBoolean("Allow-Drop") || !itemSection.isBoolean("Destroy-Dropped") || !itemSection.isBoolean("Allow-Move")) {
@@ -88,10 +113,11 @@ public class AccessItemRegistry implements Reloadable {
                 }
                 int slot = Math.abs(configItems.getInt("Slot"));
                 items.put(itemId, new AccessItem(itemId, slot, name, material, lore,
-                        itemSection.getBoolean("Join"),
-                        itemSection.getBoolean("Allow-Drop"),
-                        itemSection.getBoolean("Destroy-Dropped"),
-                        itemSection.getBoolean("Allow-Move")));
+                        itemSection.getBoolean("Join"), itemSection.getBoolean("Allow-Drop"),
+                        itemSection.getBoolean("Destroy-Dropped"), itemSection.getBoolean("Allow-Move"),
+                        formName));
+
+                isEnabled = true;
             } else {
                 logger.warn("Failed to create access item " + itemId + " because a Slot Integer value wasn't given.");
             }
@@ -101,12 +127,50 @@ public class AccessItemRegistry implements Reloadable {
     @Override
     public boolean reload() {
         items.clear();
-        fetchItems();
-
+        load();
         return true;
     }
 
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    /**
+     * Get all the Access Items
+     * @return A map whose keys are the identifiers of the access items, and the values are the access items
+     */
     public HashMap<String, AccessItem> getAccessItems() {
         return new HashMap<>(items);
+    }
+
+    /**
+     * Attempt to retrieve the Access Item that an ItemStack points to
+     * @param itemStack The ItemStack to check. If it contains null ItemMeta, this will return null.
+     * @return The Access Item if the ItemStack contained the identifier of the Access Item, and the Access Item exists. Will return null if their conditions are false.
+     */
+    @Nullable
+    public AccessItem getAccessItem(@Nonnull ItemStack itemStack) {
+        String identifier = getAccessItemId(itemStack);
+        if (identifier == null) {
+            return null;
+        } else {
+            return items.get(identifier);
+        }
+    }
+
+    /**
+     * Attempt to retrieve the Access Item ID that an ItemStack points to
+     * @param itemStack The ItemStack to check
+     * @return The AccessItem ID if the ItemStack contained the name, null if not.
+     */
+    @Nullable
+    public static String getAccessItemId(@Nonnull ItemStack itemStack) {
+        Objects.requireNonNull(itemStack);
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) {
+            return null;
+        } else {
+            return meta.getPersistentDataContainer().get(AccessItem.ACCESS_ITEM_KEY, AccessItem.ACCESS_ITEM_KEY_TYPE);
+        }
     }
 }

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
@@ -40,23 +40,23 @@ public class AccessItemRegistry implements Reloadable {
                 return;
             }
         }
-        if (!selectorConfig.contains("Items") || !selectorConfig.isConfigurationSection("Items")) {
+        if (!accessSection.contains("Items") || !accessSection.isConfigurationSection("Items")) {
             logger.warn("Not creating any access items because Selector-Item in selector.yml does not list any items!");
             return;
         }
-        ConfigurationSection configItems = Objects.requireNonNull(selectorConfig.getConfigurationSection("Items"));
+        ConfigurationSection configItems = Objects.requireNonNull(accessSection.getConfigurationSection("Items"));
 
         for (String itemId : configItems.getKeys(false)) {
             if (!configItems.isConfigurationSection(itemId)) {
                 continue;
             }
-            ConfigurationSection itemSection = configItems.getConfigurationSection(itemId);
-            Objects.requireNonNull(itemSection);
+            ConfigurationSection itemEntry = configItems.getConfigurationSection(itemId);
+            Objects.requireNonNull(itemEntry);
 
             // Get the material
             Material material;
-            if (itemSection.contains("Material", true)) {
-                String materialName = itemSection.getString("Material");
+            if (itemEntry.contains("Material", true)) {
+                String materialName = itemEntry.getString("Material");
                 Objects.requireNonNull(materialName);
                 material = Material.getMaterial(materialName);
                 if (material == null) {
@@ -78,8 +78,8 @@ public class AccessItemRegistry implements Reloadable {
 
             // Set the display name in the meta
             String name;
-            if (itemSection.contains("Name", true)) {
-                name = itemSection.getString("Selector-Item.Name");
+            if (itemEntry.contains("Name", true)) {
+                name = itemEntry.getString("Name");
                 Objects.requireNonNull(name);
             } else {
                 SelectorLogger.getLogger().warn("Failed to find Selector-Item. " + itemId + ".Name in the config! Defaulting to '§6Server Selector'.");
@@ -89,8 +89,8 @@ public class AccessItemRegistry implements Reloadable {
 
             // Set the lore in the meta
             List<String> lore;
-            if (itemSection.contains("Lore", true) && itemSection.isList("Lore")) {
-                lore = itemSection.getStringList("Selector-Item.Lore");
+            if (itemEntry.contains("Lore", true) && itemEntry.isList("Lore")) {
+                lore = itemEntry.getStringList("Lore");
             } else {
                 lore = Collections.emptyList();
             }
@@ -99,22 +99,22 @@ public class AccessItemRegistry implements Reloadable {
             // Set the meta and set the field
             item.setItemMeta(meta);
 
-            if (!itemSection.contains("Form") || !itemSection.isString("Form")) {
+            if (!itemEntry.contains("Form") || !itemEntry.isString("Form")) {
                 logger.warn("Access item: " + itemId + " does not contain a form! Not registering the item.");
                 continue;
             }
-            String formName = Objects.requireNonNull(itemSection.getString("Form"));
+            String formName = Objects.requireNonNull(itemEntry.getString("Form"));
 
-            if (itemSection.contains("Slot", true) && itemSection.isInt("Slot")) {
-                if ( !itemSection.contains("Join") || !itemSection.contains("Allow-Drop") || !itemSection.contains("Destroy-Dropped") || !itemSection.contains("Allow-Move")
-                || !itemSection.isBoolean("Join") || !itemSection.isBoolean("Allow-Drop") || !itemSection.isBoolean("Destroy-Dropped") || !itemSection.isBoolean("Allow-Move")) {
+            if (itemEntry.contains("Slot", true) && itemEntry.isInt("Slot")) {
+                if ( !itemEntry.contains("Join") || !itemEntry.contains("Allow-Drop") || !itemEntry.contains("Destroy-Dropped") || !itemEntry.contains("Allow-Move")
+                || !itemEntry.isBoolean("Join") || !itemEntry.isBoolean("Allow-Drop") || !itemEntry.isBoolean("Destroy-Dropped") || !itemEntry.isBoolean("Allow-Move")) {
                     logger.warn("Failed to create access item " + itemId + " because it is missing config values!");
                     continue;
                 }
-                int slot = Math.abs(configItems.getInt("Slot"));
+                int slot = Math.abs(itemEntry.getInt("Slot"));
                 items.put(itemId, new AccessItem(itemId, slot, name, material, lore,
-                        itemSection.getBoolean("Join"), itemSection.getBoolean("Allow-Drop"),
-                        itemSection.getBoolean("Destroy-Dropped"), itemSection.getBoolean("Allow-Move"),
+                        itemEntry.getBoolean("Join"), itemEntry.getBoolean("Allow-Drop"),
+                        itemEntry.getBoolean("Destroy-Dropped"), itemEntry.getBoolean("Allow-Move"),
                         formName));
 
                 isEnabled = true;

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
@@ -34,18 +34,18 @@ public class AccessItemRegistry implements Reloadable {
         SelectorLogger logger = SelectorLogger.getLogger();
 
         FileConfiguration selectorConfig = GeyserHubMain.getInstance().getConfigManager().getFileConfiguration(ConfigId.SELECTOR);
-        if (!selectorConfig.contains("Selector-Item") || !selectorConfig.isConfigurationSection("Selector-Item")) {
-            logger.warn("Not creating any access items because selector.yml does not contain the Selector-Item config!");
+        if (!selectorConfig.contains("Access-Items") || !selectorConfig.isConfigurationSection("Access-Items")) {
+            logger.warn("Not creating any access items because selector.yml does not contain the Access-Items config!");
             return;
         }
-        ConfigurationSection accessSection = Objects.requireNonNull(selectorConfig.getConfigurationSection("Selector-Item"));
+        ConfigurationSection accessSection = Objects.requireNonNull(selectorConfig.getConfigurationSection("Access-Items"));
         if (accessSection.contains("Enable") && accessSection.isBoolean("Enable")) {
             if (!accessSection.getBoolean("Enable")) {
                 return;
             }
         }
         if (!accessSection.contains("Items") || !accessSection.isConfigurationSection("Items")) {
-            logger.warn("Not creating any access items because Selector-Item in selector.yml does not list any items!");
+            logger.warn("Not creating any access items because Access-Items in selector.yml does not list any items!");
             return;
         }
         ConfigurationSection configItems = Objects.requireNonNull(accessSection.getConfigurationSection("Items"));
@@ -68,7 +68,7 @@ public class AccessItemRegistry implements Reloadable {
                     material = Material.COMPASS;
                 }
             } else {
-                SelectorLogger.getLogger().warn("Failed to find Selector-Item. " + itemId + ".Material in the config! Defaulting to COMPASS.");
+                SelectorLogger.getLogger().warn("Failed to find Access-Items. " + itemId + ".Material in the config! Defaulting to COMPASS.");
                 material = Material.COMPASS;
             }
 
@@ -86,7 +86,7 @@ public class AccessItemRegistry implements Reloadable {
                 name = itemEntry.getString("Name");
                 Objects.requireNonNull(name);
             } else {
-                SelectorLogger.getLogger().warn("Failed to find Selector-Item. " + itemId + ".Name in the config! Defaulting to '§6Server Selector'.");
+                SelectorLogger.getLogger().warn("Failed to find Access-Items. " + itemId + ".Name in the config! Defaulting to '§6Server Selector'.");
                 name = "§6Server Selector";
             }
             meta.setDisplayName(name);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/AccessItemRegistry.java
@@ -26,6 +26,10 @@ public class AccessItemRegistry implements Reloadable {
         ReloadableRegistry.registerReloadable(this);
     }
 
+    /**
+     * Adds access items in {@link this#items} from {@link ConfigId#SELECTOR}.
+     * Does not clear existing items.
+     */
     private void load() {
         SelectorLogger logger = SelectorLogger.getLogger();
 

--- a/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
@@ -88,19 +88,19 @@ public class CommonMenuListeners implements Listener {
 
         Player player = event.getPlayer();
 
+        // Remove any access items that are already in the inventory
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null) {
+                continue;
+            }
+            if (AccessItemRegistry.getAccessItemId(item) != null) {
+                player.getInventory().remove(item);
+            }
+        }
+
         for (AccessItem accessItem : accessItemRegistry.getAccessItems().values()) {
             if (accessItem.onJoin) {
                 ItemStack accessItemStack = accessItem.getItemStack(player); // todo update placeholders
-
-                // Remove any access items that are already in the inventory
-                for (ItemStack item : player.getInventory().getContents()) {
-                    if (item == null) {
-                        continue;
-                    }
-                    if (AccessItemRegistry.getAccessItemId(item) != null) {
-                        player.getInventory().remove(item);
-                    }
-                }
 
                 int desiredSlot = accessItem.slot;
                 ItemStack oldItem = player.getInventory().getItem(desiredSlot);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
@@ -34,12 +34,12 @@ public class CommonMenuListeners implements Listener {
         }
 
         if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            event.setCancelled(true); // todo: should we cancel this?
             Player player = event.getPlayer();
             ItemStack item = event.getItem();
             if (item != null) {
                 AccessItem accessItem = accessItemRegistry.getAccessItem(item);
                 if (accessItem != null) {
+                    event.setCancelled(true); // todo: what happens if we don't cancel this? does the chest open before or after ours?
                     String formName = accessItem.formName;
                     MenuUtils.sendForm(player, bedrockFormRegistry, javaMenuRegistry, formName);
                 }
@@ -94,7 +94,10 @@ public class CommonMenuListeners implements Listener {
 
                 // Remove any access items that are already in the inventory
                 for (ItemStack item : player.getInventory().getContents()) {
-                    if (AccessItemRegistry.getAccessItemId(item) != null) { // todo: this might cause an npe
+                    if (item == null) {
+                        continue;
+                    }
+                    if (AccessItemRegistry.getAccessItemId(item) != null) {
                         player.getInventory().remove(item);
                     }
                 }

--- a/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
@@ -98,6 +98,7 @@ public class CommonMenuListeners implements Listener {
             }
         }
 
+        boolean setHeldSlot = false; // If we have changed the item being held
         for (AccessItem accessItem : accessItemRegistry.getAccessItems().values()) {
             if (accessItem.onJoin) {
                 ItemStack accessItemStack = accessItem.getItemStack(player); // todo update placeholders
@@ -109,7 +110,7 @@ public class CommonMenuListeners implements Listener {
                     player.getInventory().setItem(desiredSlot, accessItemStack);
                     success = true;
                 } else {
-                    for (int i = 0; i < 10; i++) {
+                    for (int i = 0; i < 10 && i != desiredSlot; i++) {
                         if (player.getInventory().getItem(i) == null || Objects.requireNonNull(player.getInventory().getItem(i)).getType() == Material.AIR) {
                             player.getInventory().setItem(i, oldItem);
                             player.getInventory().setItem(desiredSlot, accessItemStack);
@@ -119,8 +120,10 @@ public class CommonMenuListeners implements Listener {
                     }
                     // If the player doesn't have the space in their hotbar then they don't get it
                 }
-                if (success) {
+                if (success && !setHeldSlot) {
+                    // Set the held item to the first access item
                     event.getPlayer().getInventory().setHeldItemSlot(accessItem.slot);
+                    setHeldSlot = true;
                 }
             }
         }

--- a/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
@@ -34,12 +34,13 @@ public class CommonMenuListeners implements Listener {
         }
 
         if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            Player player = event.getPlayer();
             ItemStack item = event.getItem();
             if (item != null) {
                 AccessItem accessItem = accessItemRegistry.getAccessItem(item);
                 if (accessItem != null) {
                     event.setCancelled(true); // todo: what happens if we don't cancel this? does the chest open before or after ours?
+
+                    Player player = event.getPlayer();
                     String formName = accessItem.formName;
                     MenuUtils.sendForm(player, bedrockFormRegistry, javaMenuRegistry, formName);
                 }
@@ -107,9 +108,11 @@ public class CommonMenuListeners implements Listener {
                 ItemStack oldItem = player.getInventory().getItem(desiredSlot);
                 boolean success = false;
                 if (oldItem == null || oldItem.getType() == Material.AIR) {
+                    // put the item in the desired place
                     player.getInventory().setItem(desiredSlot, accessItemStack);
                     success = true;
                 } else {
+                    // find somewhere else to put it in the hotbar
                     for (int i = 0; i < 10 && i != desiredSlot; i++) {
                         if (player.getInventory().getItem(i) == null || Objects.requireNonNull(player.getInventory().getItem(i)).getType() == Material.AIR) {
                             player.getInventory().setItem(i, oldItem);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/CommonMenuListeners.java
@@ -28,7 +28,7 @@ public class CommonMenuListeners implements Listener {
     }
 
     @EventHandler
-    public void onInteract(PlayerInteractEvent event) { // open the menu through the access item
+    public void onInteract(PlayerInteractEvent event) { // opening menus through access items
         if (!accessItemRegistry.isEnabled()) {
             return;
         }
@@ -49,7 +49,7 @@ public class CommonMenuListeners implements Listener {
     }
 
     @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) { // keep the access item in place (depending on config)
+    public void onInventoryClick(InventoryClickEvent event) { // keep the access items in place
         if (!accessItemRegistry.isEnabled()) {
             return;
         }
@@ -65,7 +65,7 @@ public class CommonMenuListeners implements Listener {
     }
 
     @EventHandler
-    public void onPlayerDropItem(PlayerDropItemEvent event) { // don't let the access item be dropped, destroy it if it is (depending on config)
+    public void onPlayerDropItem(PlayerDropItemEvent event) { // don't let the access item be dropped, destroy it if it is
         if (!accessItemRegistry.isEnabled()) {
             return;
         }
@@ -95,6 +95,8 @@ public class CommonMenuListeners implements Listener {
                 continue;
             }
             if (AccessItemRegistry.getAccessItemId(item) != null) {
+                // Even if this specific item/access item is no longer registered
+                // The fact it has the ID inside of it means it once was or still is
                 player.getInventory().remove(item);
             }
         }
@@ -102,7 +104,7 @@ public class CommonMenuListeners implements Listener {
         boolean setHeldSlot = false; // If we have changed the item being held
         for (AccessItem accessItem : accessItemRegistry.getAccessItems().values()) {
             if (accessItem.onJoin) {
-                ItemStack accessItemStack = accessItem.getItemStack(player); // todo update placeholders
+                ItemStack accessItemStack = accessItem.getItemStack(player); // todo update placeholders after the fact. but when?
 
                 int desiredSlot = accessItem.slot;
                 ItemStack oldItem = player.getInventory().getItem(desiredSlot);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
@@ -2,12 +2,17 @@ package dev.projectg.geyserhub.module.menu;
 
 import dev.projectg.geyserhub.GeyserHubMain;
 import dev.projectg.geyserhub.SelectorLogger;
+import dev.projectg.geyserhub.module.menu.bedrock.BedrockForm;
+import dev.projectg.geyserhub.module.menu.bedrock.BedrockFormRegistry;
+import dev.projectg.geyserhub.module.menu.java.JavaMenu;
+import dev.projectg.geyserhub.module.menu.java.JavaMenuRegistry;
 import dev.projectg.geyserhub.utils.PlaceholderUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.geysermc.floodgate.api.FloodgateApi;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -22,6 +27,33 @@ public class MenuUtils {
 
     public static final String playerPrefix = "player;";
     public static final String consolePrefix = "console;";
+
+    public static void sendForm(@Nonnull Player player, @Nonnull BedrockFormRegistry bedrockRegistry, @Nonnull JavaMenuRegistry javaMenuRegistry, @Nonnull String formName) {
+        if (FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId())) {
+            if (bedrockRegistry.isEnabled()) {
+                if (bedrockRegistry.getFormNames().contains(formName)) {
+                    BedrockForm form = Objects.requireNonNull(bedrockRegistry.getMenu(formName));
+                    form.sendForm(FloodgateApi.getInstance().getPlayer(player.getUniqueId()));
+                } else {
+                    player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, that form doesn't exist! Specify a form with '/ghub form <form>\'");
+                }
+            } else {
+                player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, Bedrock forms are disabled!");
+            }
+        } else {
+            if (javaMenuRegistry.isEnabled()) {
+                if (javaMenuRegistry.getMenuNames().contains(formName)) {
+                    JavaMenu menu = Objects.requireNonNull(javaMenuRegistry.getMenu(formName));
+                    menu.sendMenu(player);
+                } else {
+                    player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, that form doesn't exist! Specify a form with '/ghub form <form>'");
+                }
+            } else {
+                player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, Java menus are disabled!");
+            }
+        }
+
+    }
 
     /**
      * @param commands Commands list, an empty list can be passed for no commands.
@@ -96,7 +128,7 @@ public class MenuUtils {
         Objects.requireNonNull(buttonData);
         SelectorLogger logger = SelectorLogger.getLogger();
 
-        if (buttonData.contains("Commands") && buttonData.isList("Commands")) {
+        if (buttonData.contains("Commands", true) && buttonData.isList("Commands")) {
             if (buttonData.getStringList("Commands").isEmpty()) {
                 logger.warn(getParentName(buttonData) + "." + buttonData.getName() + " contains commands list but the list was empty.");
             } else {
@@ -115,7 +147,7 @@ public class MenuUtils {
     public static String getServer(@Nonnull ConfigurationSection buttonData) {
         Objects.requireNonNull(buttonData);
 
-        if (buttonData.contains("Server") && buttonData.isString("Server")) {
+        if (buttonData.contains("Server", true) && buttonData.isString("Server")) {
             return Objects.requireNonNull(buttonData.getString("Server"));
         }
         return null;

--- a/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
@@ -31,22 +31,22 @@ public class MenuUtils {
     public static void sendForm(@Nonnull Player player, @Nonnull BedrockFormRegistry bedrockRegistry, @Nonnull JavaMenuRegistry javaMenuRegistry, @Nonnull String formName) {
         if (FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId())) {
             if (bedrockRegistry.isEnabled()) {
-                if (bedrockRegistry.getFormNames().contains(formName)) {
-                    BedrockForm form = Objects.requireNonNull(bedrockRegistry.getMenu(formName));
-                    form.sendForm(FloodgateApi.getInstance().getPlayer(player.getUniqueId()));
+                BedrockForm form = bedrockRegistry.getMenu(formName);
+                if (form == null) {
+                    player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, that form doesn't exist! Specify a form with '/ghub form <form>'");
                 } else {
-                    player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, that form doesn't exist! Specify a form with '/ghub form <form>\'");
+                    form.sendForm(FloodgateApi.getInstance().getPlayer(player.getUniqueId()));
                 }
             } else {
                 player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, Bedrock forms are disabled!");
             }
         } else {
             if (javaMenuRegistry.isEnabled()) {
-                if (javaMenuRegistry.getMenuNames().contains(formName)) {
-                    JavaMenu menu = Objects.requireNonNull(javaMenuRegistry.getMenu(formName));
-                    menu.sendMenu(player);
-                } else {
+                JavaMenu menu = javaMenuRegistry.getMenu(formName);
+                if (menu == null) {
                     player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, that form doesn't exist! Specify a form with '/ghub form <form>'");
+                } else {
+                    menu.sendMenu(player);
                 }
             } else {
                 player.sendMessage("[GeyserHub] " + ChatColor.RED + "Sorry, Java menus are disabled!");

--- a/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
@@ -30,6 +30,15 @@ public class MenuUtils {
     public static final String playerPrefix = "player;";
     public static final String consolePrefix = "console;";
 
+    /**
+     * Sends a given form, identified by its name, to a BE or JE player.
+     * If the form does not exist for their platform, they will be sent a message.
+     * If forms are disabled on their platform, they will be sent a message.
+     * @param player The {@link Player} to send the form to
+     * @param bedrockRegistry The registry to pull bedrock forms from
+     * @param javaMenuRegistry The registry to pull java inventory GUIs from
+     * @param formName The name of the form to open
+     */
     public static void sendForm(@Nonnull Player player, @Nonnull BedrockFormRegistry bedrockRegistry, @Nonnull JavaMenuRegistry javaMenuRegistry, @Nonnull String formName) {
         if (FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId())) {
             if (bedrockRegistry.isEnabled()) {

--- a/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/MenuUtils.java
@@ -129,10 +129,11 @@ public class MenuUtils {
         SelectorLogger logger = SelectorLogger.getLogger();
 
         if (buttonData.contains("Commands", true) && buttonData.isList("Commands")) {
-            if (buttonData.getStringList("Commands").isEmpty()) {
+            List<String> commands = buttonData.getStringList("Commands");
+            if (commands.isEmpty()) {
                 logger.warn(getParentName(buttonData) + "." + buttonData.getName() + " contains commands list but the list was empty.");
             } else {
-                return buttonData.getStringList("Commands");
+                return commands;
             }
         }
         return Collections.emptyList();

--- a/src/main/java/dev/projectg/geyserhub/module/menu/bedrock/BedrockForm.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/bedrock/BedrockForm.java
@@ -60,13 +60,13 @@ public class BedrockForm {
         formName = configSection.getName();
 
         // Get the Title and Content
-        if (!configSection.contains("Title", true) || !configSection.contains("Content")) {
+        if (configSection.contains("Title", true) && configSection.contains("Content", true)) {
+            this.title = Objects.requireNonNull(configSection.getString("Title"));
+            this.content = Objects.requireNonNull(configSection.getString("Content"));
+        } else {
             logger.warn("Bedrock Form: "  + formName + " does not contain a Title or Content value! Failed to create the form.");
             isEnabled = false;
             return;
-        } else {
-            this.title = Objects.requireNonNull(configSection.getString("Title"));
-            this.content = Objects.requireNonNull(configSection.getString("Content"));
         }
 
         // Get our Buttons

--- a/src/main/java/dev/projectg/geyserhub/module/menu/bedrock/BedrockForm.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/bedrock/BedrockForm.java
@@ -60,7 +60,7 @@ public class BedrockForm {
         formName = configSection.getName();
 
         // Get the Title and Content
-        if (!configSection.contains("Title") || !configSection.contains("Content")) {
+        if (!configSection.contains("Title", true) || !configSection.contains("Content")) {
             logger.warn("Bedrock Form: "  + formName + " does not contain a Title or Content value! Failed to create the form.");
             isEnabled = false;
             return;

--- a/src/main/java/dev/projectg/geyserhub/module/menu/bedrock/BedrockFormRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/bedrock/BedrockFormRegistry.java
@@ -11,10 +11,8 @@ import org.bukkit.configuration.file.FileConfiguration;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class BedrockFormRegistry implements Reloadable {
 
@@ -98,17 +96,9 @@ public class BedrockFormRegistry implements Reloadable {
     }
 
     /**
-     * @return A copy of the keyset of the current enabled menus
-     */
-    @Nonnull
-    public Set<String> getFormNames() {
-        return new HashSet<>(enabledForms.keySet());
-    }
-
-    /**
-     * Get a Java menu, based off its name.
+     * Get a BedrockForm, based off its name.
      * @param menuName The menu name
-     * @return the JavaMenu, null if it doesn't exist.
+     * @return the BedrockForm, null if it doesn't exist.
      */
     @Nullable
     public BedrockForm getMenu(@Nonnull String menuName) {

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
@@ -66,7 +66,7 @@ public class JavaMenu {
         menuName = configSection.getName();
 
         // Get the inventory title and size
-        if (configSection.contains("Title", true) && configSection.contains("Size") && configSection.isInt("Size")) {
+        if (configSection.contains("Title", true) && configSection.contains("Size", true) && configSection.isInt("Size")) {
             title = Objects.requireNonNull(configSection.getString("Title"));
             size = Math.abs(configSection.getInt("Size"));
             logger.debug("Java Menu: " + menuName + " has Title: " + title);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
@@ -235,38 +235,44 @@ public class JavaMenu {
      */
     private void validateSize() {
 
-        int minimumSize = 0; // used for later
-        for (int slot = 0; slot < buttons.size(); slot++) {
-            if (buttons.containsKey(slot)) {
-                if (slot + 1 > MAX_SIZE) {
-                    buttons.remove(slot);
-                    logger.warn("Removing button with index " + slot + " from Java menu " + menuName + " because it exceeds the max index of " + (MAX_SIZE - 1) + "(max size of " + MAX_SIZE + ")");
-                } else {
-                    minimumSize = Math.max(slot + 1, minimumSize);
-                }
-            }
-        }
-
+        // ensure size is not greater than max size
         if (size > MAX_SIZE) {
             size = MAX_SIZE;
             logger.warn("Setting the size of Java menu " + menuName + " to " + MAX_SIZE + " because it exceeded the maximum size.");
-            return;
         }
 
-        // Increase the size if the buttons don't fit
-        boolean increasedSize = false;
-        if (minimumSize > size) {
-            logger.warn("Java Menu: " + menuName + " has a button that needs a size of " + minimumSize + ", but the inventory size is only " + size);
-            size = minimumSize;
+        int min_size = 5; // assume an initial minimum size of 5
+
+        // Remove buttons that are impossible to fit in any inventory and determined the minimum size to fit all buttons.
+        for (Integer index: buttons.keySet()) {
+            if (index > MAX_SIZE - 1) {
+                logger.warn("Removing button with index " + index + " from Java menu " + menuName + " because it exceeds the max possible index of " + (MAX_SIZE - 1) + "(max possible size of " + MAX_SIZE + ")");
+                buttons.remove(index);
+                continue;
+            }
+
+            // Minimum size should be equal to or less than max size
+            min_size = Math.max(min_size, index + 1);
+        }
+
+        boolean increasedSize;
+        // Increased the size to fit all buttons if necessary.
+        // Buttons that exceeded the MAX_SIZE were not considered for the minimum size,
+        // so this should not increase the size past the maximum size.
+        if (min_size > size) {
+            size = min_size;
             increasedSize = true;
+            logger.warn("Java Menu: " + menuName + " has a button that needs a size of " + min_size + ", but the inventory size is only " + size + ". Increased size to " + min_size);
+        } else {
+            increasedSize = false;
         }
 
-        // Make sure that the inventory size is a multiple of 9, unless its the hopper size.
+        // Make sure that the inventory size is a multiple of 9, or the hopper size.
         if (size != HOPPER_SIZE && size % 9 != 0) {
             // Divide the size by 9D, round the ratio up to the next int value, then multiply by 9 to get the closest higher number that is a multiple of 9
             size = (int) (9*(Math.ceil(size/9D)));
             if (!increasedSize) {
-                logger.warn("Java Menu: " + menuName + " size is not 5 (allowed value, for hopper), and is not a multiple of 9 between 9 and 54 (allowed values for chests). Increasing size to " + size);
+                logger.warn("Java Menu: " + menuName + " size is not 5 (allowed value for hopper), and is not a multiple of 9 between 9 and 54 (allowed values for chests). Increasing size to " + size);
             }
         }
     }
@@ -296,16 +302,16 @@ public class JavaMenu {
             ItemButton button = buttons.get(slot);
 
             // Construct the item
-            ItemStack serverStack = new ItemStack(button.getMaterial());
-            ItemMeta itemMeta = serverStack.getItemMeta();
+            ItemStack buttonItem = new ItemStack(button.getMaterial());
+            ItemMeta itemMeta = buttonItem.getItemMeta();
             if (itemMeta == null) {
                 logger.warn("Java Button: " + menuName + "." + slot + " with Material: " + button.getMaterial() + " returned null ItemMeta, not adding the button!");
             } else {
                 itemMeta.setDisplayName(PlaceholderUtils.setPlaceholders(player, button.getDisplayName()));
                 itemMeta.setLore(PlaceholderUtils.setPlaceholders(player, button.getLore()));
                 itemMeta.getPersistentDataContainer().set(MENU_NAME_KEY, PersistentDataType.STRING, menuName);
-                serverStack.setItemMeta(itemMeta);
-                selectorGUI.setItem(slot, serverStack);
+                buttonItem.setItemMeta(itemMeta);
+                selectorGUI.setItem(slot, buttonItem);
             }
         }
 

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
@@ -25,8 +25,8 @@ public class JavaMenu {
     public static final int MAX_SIZE = 54;
     public static final int HOPPER_SIZE = 5;
 
-    public static final NamespacedKey MENU_NAME_KEY = new NamespacedKey(GeyserHubMain.getInstance(), "geyserHubButton");
-    public static final PersistentDataType<String, String>  MENU_NAME_TYPE = PersistentDataType.STRING;
+    protected static final NamespacedKey BUTTON_KEY = new NamespacedKey(GeyserHubMain.getInstance(), "geyserHubButton");
+    protected static final PersistentDataType<String, String> BUTTON_KEY_TYPE = PersistentDataType.STRING;
 
     private final SelectorLogger logger;
 
@@ -303,7 +303,7 @@ public class JavaMenu {
             } else {
                 itemMeta.setDisplayName(PlaceholderUtils.setPlaceholders(player, button.getDisplayName()));
                 itemMeta.setLore(PlaceholderUtils.setPlaceholders(player, button.getLore()));
-                itemMeta.getPersistentDataContainer().set(MENU_NAME_KEY, PersistentDataType.STRING, menuName);
+                itemMeta.getPersistentDataContainer().set(BUTTON_KEY, PersistentDataType.STRING, menuName);
                 serverStack.setItemMeta(itemMeta);
                 selectorGUI.setItem(slot, serverStack);
             }

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenu.java
@@ -25,7 +25,7 @@ public class JavaMenu {
     public static final int MAX_SIZE = 54;
     public static final int HOPPER_SIZE = 5;
 
-    public static final NamespacedKey MENU_NAME_KEY = new NamespacedKey(GeyserHubMain.getInstance(), "geyserHubMenu");
+    public static final NamespacedKey MENU_NAME_KEY = new NamespacedKey(GeyserHubMain.getInstance(), "geyserHubButton");
     public static final PersistentDataType<String, String>  MENU_NAME_TYPE = PersistentDataType.STRING;
 
     private final SelectorLogger logger;
@@ -66,7 +66,7 @@ public class JavaMenu {
         menuName = configSection.getName();
 
         // Get the inventory title and size
-        if (configSection.contains("Title") && configSection.contains("Size") && configSection.isInt("Size")) {
+        if (configSection.contains("Title", true) && configSection.contains("Size") && configSection.isInt("Size")) {
             title = Objects.requireNonNull(configSection.getString("Title"));
             size = Math.abs(configSection.getInt("Size"));
             logger.debug("Java Menu: " + menuName + " has Title: " + title);

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuListeners.java
@@ -9,7 +9,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -33,17 +32,14 @@ public class JavaMenuListeners implements Listener {
 
         ItemStack item = event.getCurrentItem();
         if (item != null) {
-            ItemMeta meta = item.getItemMeta();
-            if (meta != null) {
-                String menuName = meta.getPersistentDataContainer().get(JavaMenu.MENU_NAME_KEY, JavaMenu.MENU_NAME_TYPE);
-                if (menuName != null) {
-                    event.setCancelled(true);
-                    JavaMenu menu = javaMenuRegistry.getMenu(menuName);
-                    if (menu == null) {
-                        logger.warn("Failed to find any Java menu under the name '" + menuName + "' in order to process inventory click by player: " + player.getName());
-                    } else {
-                        menu.process(event.getSlot(), event.isRightClick(), player);
-                    }
+            String menuName = JavaMenuRegistry.getMenuName(item);
+            if (menuName != null) {
+                event.setCancelled(true);
+                JavaMenu menu = javaMenuRegistry.getMenu(menuName);
+                if (menu == null) {
+                    logger.warn("Failed to find any Java menu under the name '" + menuName + "' in order to process inventory click by player: " + player.getName());
+                } else {
+                    menu.process(event.getSlot(), event.isRightClick(), player);
                 }
             }
         }

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuListeners.java
@@ -23,6 +23,8 @@ public class JavaMenuListeners implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
+        // This is used for processing inventory clicks WITHIN the java menu GUI
+
         FileConfiguration config = GeyserHubMain.getInstance().getConfigManager().getFileConfiguration(ConfigId.SELECTOR);
         if (!config.getBoolean("Java-Selector.Enable")) {
             return;
@@ -32,15 +34,12 @@ public class JavaMenuListeners implements Listener {
 
         ItemStack item = event.getCurrentItem();
         if (item != null) {
-            String menuName = JavaMenuRegistry.getMenuName(item);
-            if (menuName != null) {
+            JavaMenu menu = javaMenuRegistry.getMenu(item);
+            if (menu == null) {
+                logger.warn("Failed to find any Java menu for the itemstack of'" + (item.hasItemMeta() ? Objects.requireNonNull(item.getItemMeta()).getDisplayName() : item.toString()) + "' in order to process inventory click by player: " + player.getName());
+            } else {
                 event.setCancelled(true);
-                JavaMenu menu = javaMenuRegistry.getMenu(menuName);
-                if (menu == null) {
-                    logger.warn("Failed to find any Java menu under the name '" + menuName + "' in order to process inventory click by player: " + player.getName());
-                } else {
-                    menu.process(event.getSlot(), event.isRightClick(), player);
-                }
+                menu.process(event.getSlot(), event.isRightClick(), player);
             }
         }
     }

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuListeners.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuListeners.java
@@ -3,7 +3,6 @@ package dev.projectg.geyserhub.module.menu.java;
 import dev.projectg.geyserhub.GeyserHubMain;
 import dev.projectg.geyserhub.SelectorLogger;
 import dev.projectg.geyserhub.config.ConfigId;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -26,7 +25,7 @@ public class JavaMenuListeners implements Listener {
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
         FileConfiguration config = GeyserHubMain.getInstance().getConfigManager().getFileConfiguration(ConfigId.SELECTOR);
-        if (!config.getBoolean("Java-Selector.Enable")){
+        if (!config.getBoolean("Java-Selector.Enable")) {
             return;
         }
         Player player = (Player) event.getWhoClicked();

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuRegistry.java
@@ -107,7 +107,7 @@ public class JavaMenuRegistry implements Reloadable {
     }
 
     /**
-     * Attempt to retrieve the menu that an ItemStack is contained in
+     * Attempt to retrieve the menu that an ItemStack points to
      * @param itemStack The ItemStack to check. If it contains null ItemMeta, this will return null.
      * @return The menu if the ItemStack contained the menu name and the menu exists. If no menu name was contained or the menu contained doesn't exist, this will return null.
      */
@@ -127,7 +127,7 @@ public class JavaMenuRegistry implements Reloadable {
      * @return The menu name if the ItemStack contained the menu name, null if not. ItemStacks with null ItemMeta will always return null.
      */
     @Nullable
-    public static String getMenuName(@Nonnull ItemStack itemStack) {
+    public String getMenuName(@Nonnull ItemStack itemStack) {
         Objects.requireNonNull(itemStack);
         ItemMeta meta = itemStack.getItemMeta();
         if (meta != null) {

--- a/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/module/menu/java/JavaMenuRegistry.java
@@ -7,6 +7,8 @@ import dev.projectg.geyserhub.reloadable.Reloadable;
 import dev.projectg.geyserhub.reloadable.ReloadableRegistry;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -94,14 +96,6 @@ public class JavaMenuRegistry implements Reloadable {
     }
 
     /**
-     * @return A copy of the keyset of the current enabled menus
-     */
-    @Nonnull
-    public Set<String> getMenuNames() {
-        return new HashSet<>(enabledMenus.keySet());
-    }
-
-    /**
      * Get a Java menu, based off its name.
      * @param menuName The menu name
      * @return the JavaMenu, null if it doesn't exist.
@@ -110,6 +104,36 @@ public class JavaMenuRegistry implements Reloadable {
     public JavaMenu getMenu(@Nonnull String menuName) {
         Objects.requireNonNull(menuName);
         return enabledMenus.get(menuName);
+    }
+
+    /**
+     * Attempt to retrieve the menu that an ItemStack is contained in
+     * @param itemStack The ItemStack to check. If it contains null ItemMeta, this will return null.
+     * @return The menu if the ItemStack contained the menu name and the menu exists. If no menu name was contained or the menu contained doesn't exist, this will return null.
+     */
+    @Nullable
+    public JavaMenu getMenu(@Nonnull ItemStack itemStack) {
+        String menuName = getMenuName(itemStack);
+        if (menuName == null) {
+            return null;
+        } else {
+            return getMenu(menuName);
+        }
+    }
+
+    /**
+     * Attempt to retrieve the menu name that an ItemStack is contained in
+     * @param itemStack The ItemStack to check
+     * @return The menu name if the ItemStack contained the menu name, null if not. ItemStacks with null ItemMeta will always return null.
+     */
+    @Nullable
+    public static String getMenuName(@Nonnull ItemStack itemStack) {
+        Objects.requireNonNull(itemStack);
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            return meta.getPersistentDataContainer().get(JavaMenu.BUTTON_KEY, JavaMenu.BUTTON_KEY_TYPE);
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/dev/projectg/geyserhub/module/teleporter/JoinTeleporter.java
+++ b/src/main/java/dev/projectg/geyserhub/module/teleporter/JoinTeleporter.java
@@ -59,7 +59,7 @@ public class JoinTeleporter implements Listener, Reloadable {
         ConfigurationSection section = config.getConfigurationSection("Join-Teleporter");
         Objects.requireNonNull(section);
 
-        if (section.contains("Enable") && section.isBoolean("Enable")) {
+        if (section.contains("Enable", true) && section.isBoolean("Enable")) {
             if (section.getBoolean("Enable")) {
                 return setLocation(section);
             } else {
@@ -79,7 +79,7 @@ public class JoinTeleporter implements Listener, Reloadable {
     private boolean setLocation(@Nonnull ConfigurationSection section) {
         SelectorLogger logger = SelectorLogger.getLogger();
 
-        if (!(section.contains("World") && section.isString("World"))) {
+        if (!(section.contains("World", true) && section.isString("World"))) {
             logger.severe("Join-Teleporter config section does not contain a valid World string, skipping module!");
             return false;
         }
@@ -91,7 +91,7 @@ public class JoinTeleporter implements Listener, Reloadable {
             return false;
         }
 
-        if (section.contains("Coordinates") && section.isString("Coordinates")) {
+        if (section.contains("Coordinates", true) && section.isString("Coordinates")) {
             // Make sure the given coordinates are in the correct format
             String composedCoords = section.getString("Coordinates");
             Objects.requireNonNull(composedCoords);

--- a/src/main/java/dev/projectg/geyserhub/reloadable/ReloadableRegistry.java
+++ b/src/main/java/dev/projectg/geyserhub/reloadable/ReloadableRegistry.java
@@ -25,13 +25,6 @@ public class ReloadableRegistry {
         reloadables.add(reloadable);
     }
 
-    /**
-     * @return A copy of all registered reloadables
-     */
-    public static Reloadable[] getRegisteredReloadables() {
-        return reloadables.toArray(new Reloadable[0]);
-    }
-
     public static boolean reloadAll() {
         SelectorLogger logger = SelectorLogger.getLogger();
 
@@ -48,7 +41,7 @@ public class ReloadableRegistry {
         logger.info("Reloaded the configuration, reloading modules...");
 
         boolean success = true;
-        for (Reloadable reloadable : ReloadableRegistry.getRegisteredReloadables()) {
+        for (Reloadable reloadable : reloadables) {
             if (!reloadable.reload()) {
                 logger.severe(ChatColor.RED + "Failed to reload class: " + ChatColor.RESET + reloadable.getClass().toString());
                 success = false;

--- a/src/main/resources/selector.yml
+++ b/src/main/resources/selector.yml
@@ -1,7 +1,9 @@
 # Item to access the default menu
 Selector-Item:
-  default:
-    Material: COMPASS
+  Enable: true
+  Items:
+    default:
+      Material: COMPASS
       Name: "§6Server Selector"
       Lore:
         - "Right click me!"

--- a/src/main/resources/selector.yml
+++ b/src/main/resources/selector.yml
@@ -18,6 +18,15 @@ Selector-Item:
       Destroy-Dropped: true
       # Stop the player from moving the compass in their inventory
       Allow-Move: false
+    minigamesShortcut:
+      Material: CARROT_ON_A_STICK
+      Name: "§6Minigames Shortcut"
+      Slot: 5
+      Form: minigames
+      Join: true
+      Allow-Drop: true
+      Destroy-Dropped: true
+      Allow-Move: false
 
 # Please see our readme for information on configuring this section.
 # https://github.com/ProjectG-Plugins/GeyserServerSelector#Configuration
@@ -141,4 +150,4 @@ Bedrock-Selector:
           Server: "hideseek"
 
 # Don't touch this
-Config-Version: 1
+Config-Version: 2

--- a/src/main/resources/selector.yml
+++ b/src/main/resources/selector.yml
@@ -1,19 +1,21 @@
 # Item to access the default menu
 Selector-Item:
-  Material: COMPASS
-  Name: "§6Server Selector"
-  Lore:
-    - "Right click me!"
-  Slot: 4
+  default:
+    Material: COMPASS
+      Name: "§6Server Selector"
+      Lore:
+        - "Right click me!"
+      Slot: 4
+      Form: default
 
-  # Gives the player the item which they can use to open the default form
-  Join: true
-  # Stop the player from dropping the item
-  Allow-Drop: false
-  # Destroy the compass if the player drops it
-  Destroy-Dropped: true
-  # Stop the player from moving the compass in their inventory
-  Allow-Move: false
+      # Gives the player the item which they can use to open the default form
+      Join: true
+      # Stop the player from dropping the item
+      Allow-Drop: false
+      # Destroy the compass if the player drops it
+      Destroy-Dropped: true
+      # Stop the player from moving the compass in their inventory
+      Allow-Move: false
 
 # Please see our readme for information on configuring this section.
 # https://github.com/ProjectG-Plugins/GeyserServerSelector#Configuration

--- a/src/main/resources/selector.yml
+++ b/src/main/resources/selector.yml
@@ -1,5 +1,5 @@
 # Item to access the default menu
-Selector-Item:
+Access-Items:
   Enable: true
   Items:
     default:


### PR DESCRIPTION
- Add dynamic access items. More than one can be used to point to different forms, placeholder API is supported (however the placeholders are currently not updated after item creation). The version of selector.yml has been bumped to 2, but version 1 will be automatically updated to 2 (although comments will be stripped).
- Simplify some getters in the Java menu and Bedrock form registries
- Adds a boot time message on startup
- Commonify some code for sending forms
- Other misc stuff